### PR TITLE
Fix for KLatexFormula on Ubuntu

### DIFF
--- a/tofix.csv
+++ b/tofix.csv
@@ -168,6 +168,7 @@ Itch.io,itch,itch.png,itch
 Jitsi,jitsi,/usr/share/pixmaps/jitsi.svg,jitsi
 Kana Kanji Conversion Preferences,ibus-setup-kkc,/usr/share/ibus-kkc/icons/ibus-kkc.svg,ibus-setup
 Kerbal Space Program,Kerbal Space Program,steam,steam_icon_220200
+KLatexFormula,klatexformula,Icon=/usr/share/pixmaps//klatexformula-64.png,klatexformula
 Klavaro,klavaro,/usr/share/icons/hicolor/24x24/apps/klavaro.png,klavaro
 Komodo Edit,komodo-edit,/opt/komodo-edit/share/icons/komodo48.png,komodo
 LaTeXDraw,latexdraw,/usr/share/pixmaps/latexdraw32.xpm,latexdraw


### PR DESCRIPTION
It's a double slash for real.
